### PR TITLE
feat(apply): Extend workflow for AWS and add options required for Terratest used to execute examples

### DIFF
--- a/.github/workflows/_tf_plan_apply.yml
+++ b/.github/workflows/_tf_plan_apply.yml
@@ -6,7 +6,7 @@ permissions:
 defaults:
   run:
     shell: bash
-    
+
 on:
   workflow_call:
     inputs:
@@ -24,6 +24,10 @@ on:
         default: false
       idempotence:
         description: When set to true runs plan to on already applied configuration
+        type: boolean
+        default: true
+      fail_fast:
+        description: When set to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails.
         type: boolean
         default: true
       max_parallel:
@@ -67,7 +71,7 @@ jobs:
 
           echo "paths=$(echo -n "$PATHS" | jq -R -s -c 'split(",")')" >> $GITHUB_OUTPUT
           echo "tf_versions=$(echo "$TFVER " | jq -R -s -c 'split(" ")[:-1]')" >> $GITHUB_OUTPUT
-        
+
   terraform:
     needs: [prerequisites]
     name: 'plan/apply ${{ matrix.path }}@${{ matrix.tf_version }}'
@@ -77,6 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: ${{ inputs.max_parallel }}
+      fail-fast: ${{ inputs.fail_fast }}
       matrix:
         tf_version: ${{ fromJson(needs.prerequisites.outputs.tf_versions) }}
         path: ${{ fromJson(needs.prerequisites.outputs.paths) }}
@@ -101,7 +106,16 @@ jobs:
 
       - name: run plan/apply on AWS
         if: inputs.cloud == 'aws'
-        run: echo AWS placeholder
+        timeout-minutes: ${{ inputs.apply_timeout }}
+        uses: ./.github/actions/plan_apply
+        env:
+          ASSUME_ROLE: ${{ secrets.ASSUME_ROLE }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          tf_version: ${{ matrix.tf_version }}
+          path: ${{ matrix.path }}
+          do_apply: ${{ inputs.do_apply }}
+          idempotence: ${{ inputs.idempotence }}
 
       - name: run plan/apply on GCP
         if: inputs.cloud == 'gcp'

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -16,10 +16,18 @@ on:
         description: When set to true runs plan to on already applied configuration
         type: boolean
         default: true
+      fail_fast:
+        description: When set to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails.
+        type: boolean
+        default: true
       max_parallel:
         description: Maximum parallel jobs in matrix strategy
         type: number
         default: 10
+      apply_timeout:
+        description: Maximum time to run the Terraform apply step
+        type: number
+        default: 30
       tf_version:
         description: A space delimited list of TF versions used to run the code with
         type: string
@@ -160,7 +168,7 @@ jobs:
 
   plan_apply:
     name: run plan changed examples and dependencies
-    needs: 
+    needs:
       - validate
       - tf_prereqs
     if: ${{ needs.tf_prereqs.outputs.plan_paths != '' }}
@@ -174,7 +182,9 @@ jobs:
       paths: ${{ needs.tf_prereqs.outputs.plan_paths }}
       do_apply: ${{ inputs.do_apply }}
       idempotence: ${{ inputs.idempotence }}
+      fail_fast: ${{ inputs.fail_fast }}
       max_parallel: ${{ inputs.max_parallel }}
+      apply_timeout: ${{ inputs.apply_timeout }}
     secrets: inherit
 
 
@@ -193,5 +203,5 @@ jobs:
         uses: technote-space/workflow-conclusion-action@v3
 
       - name: branch protection check validation point
-        run: | 
+        run: |
           if [[ "$WORKFLOW_CONCLUSION" == "failure" ]]; then exit 1; fi

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -14,10 +14,18 @@ on:
         description: When set to true runs plan to on already applied configuration
         type: boolean
         default: true
+      fail_fast:
+        description: When set to true, GitHub will cancel all in-progress and queued jobs in the matrix if any job in the matrix fails.
+        type: boolean
+        default: true
       max_parallel:
         description: Maximum parallel jobs in matrix strategy
         type: number
         default: 10
+      apply_timeout:
+        description: Maximum time to run the Terraform apply step
+        type: number
+        default: 30
       tf_version:
         description: A space delimited list of TF versions used to run the code with
         type: string
@@ -99,7 +107,7 @@ jobs:
 
   plan_apply:
     name: run plan and/or apply on examples
-    needs: 
+    needs:
       - validate
       - tf_prereqs
     if: ${{ needs.tf_prereqs.outputs.examples != '' }}
@@ -113,13 +121,15 @@ jobs:
       paths: ${{ needs.tf_prereqs.outputs.examples }}
       do_apply: ${{ inputs.do_apply }}
       idempotence: ${{ inputs.idempotence }}
+      fail_fast: ${{ inputs.fail_fast }}
       max_parallel: ${{ inputs.max_parallel }}
+      apply_timeout: ${{ inputs.apply_timeout }}
     secrets: inherit
 
 
   release:
     name: release sem version
-    needs: 
+    needs:
       - validate
       - pre_commit
       - plan_apply


### PR DESCRIPTION
## Description

Adding improvements:
- use OIDC for AWS
- add options required for `Terratest` used to plan & apply examples in AWS
   - `fail_fast` , which set to `false` do not cancel jobs, which are not finished (then all tests in `Terratest` can finish their work and destroy all resources)
   - `apply_timeout`, which allow to increase timeout (useful for tests, which take longer than default 30 minutes)

## Motivation and Context

#31 

Changes were proposed in order to do planning and applying examples in different way - instead of using `Terraform` directly, `Terratest` is proposed. 

## How Has This Been Tested?

From [terraform-aws-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules) it was created internal clone, which was adjusted by applying below changes:

1. add `.github/actions/plan_apply/action.yml`
1. remove `.github/workflows/ci.yml` and add `.github/workflows/pr_ci.yml`
1. remove `.github/workflows/release.yml` and add `.github/workflows/release_ci.yml`
1. create `makefile.sh` (similar to what we have in [terraform-azurerm-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules))
1. add `Makefile` for every example (similar to what we have in [terraform-azurerm-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules))
1. add `main_test.go` with Terratest for every example
1. add `Makefile` for every module (similar to what we have in [terraform-azurerm-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-azurerm-vmseries-modules))
1. fix issues with `provider` in `modules/transit_gateway_peering/versions.tf`
1. create `examples/combined_design_autoscale/example.tfvars` by copying `examples/combined_design_autoscale/example-no-natgw-lambda-no-vpc.tfvars` and setting `desired_cap` and `min_size` to 0
1. replace `github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/tests/internal/` into `github.com/PaloAltoNetworks/vm-series-gh-actions-aws/go/` in test files
1. move `tests/internal/testskeleton` and `tests/internal/helpers` into `go/testskeleton` and `go/helpers`   
1. extend `main_test.go` to do apply when environment variable `DO_APPLY` is `true`
1. extend action `plan_apply` to do `make test`, not `make plan & apply`
1. extend `main_test.go` to do destroy in defer function
1. remove `plan`, `apply`, `idempotence` from `makefile.sh` and all Makefiles
1. extend `go/testskeleton`
1. use different `main_test.go` and `Makefile` only for not refactored examples
1. fix issues with VPC peering for Panorama in `isolated_design`

In future besides applying all listed changes on [terraform-aws-vmseries-modules](https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules) still there will be a need to do below actions, which may impact `terraform-modules-vmseries-ci-workflows`:
1. add integration tests for modules (folder `tests`), which are working only with `terraform plan` (this kind of tests are going to be executed for **PR CI**)
1. simplify existing integration tests for modules (folder `tests`), which are deploying every module (this kind of tests are going to be executed for **Release CI**)
1. refactor (or remove) examples, which were not adjusted while preparing code for https://pan.dev/swfw/

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
