### PR TITLE
feat: add possibility to specify branch for _tf_plan_apply workflow

### DIFF
--- a/.github/workflows/_tf_plan_apply.yml
+++ b/.github/workflows/_tf_plan_apply.yml
@@ -42,6 +42,10 @@ on:
         description: Maximum time to run the Terraform apply step
         type: number
         default: 30
+      branch:
+        description: Branch on which the tests shoul run
+        type: string
+        default: main
 
 jobs:
 
@@ -89,6 +93,8 @@ jobs:
 
       - name: checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: run plan/apply on Azure for ${{ matrix.path }}
         if: inputs.cloud == 'azure'

--- a/.github/workflows/_tf_plan_apply.yml
+++ b/.github/workflows/_tf_plan_apply.yml
@@ -45,7 +45,7 @@ on:
       branch:
         description: Branch on which the tests shoul run
         type: string
-        default: main
+        # default: main
 
 jobs:
 


### PR DESCRIPTION
## Description

`branch` is a new, optional input for the `_tf_plan_apply` workflow.

## Motivation and Context

This will add possibility to checkout any branch. For regular CI and Release workflows this is not required, but comes in handy for ChatOPS workflows, as those by default run from the default branch.

## How Has This Been Tested?

on a copy of Azure repo

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
