### PR TITLE
fix: retag a release tag instead of a commit

### DIFF
--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -43,17 +43,14 @@ jobs:
           echo new_release_version - ${{ steps.rc.outputs.new_release_version }}
           echo last_release_version - ${{ steps.rc.outputs.last_release_version }}
           echo new_release_major_version - ${{ steps.rc.outputs.new_release_major_version }}
-          echo new_release_minor_version - ${{ steps.rc.outputs.new_release_minor_version }}
       
       - name: create major/minor release tag
         if: steps.rc.outputs.new_release_published == 'true'
         env:
           MAJOR: ${{ steps.rc.outputs.new_release_major_version }}
-          MINOR: ${{ steps.rc.outputs.new_release_minor_version }}
+          RELEASE: ${{ steps.rc.outputs.new_release_version }}
         run: |
           git config --global user.email "bot@github.com"
           git config --global user.name "github-bot"
-          git tag -fa "v$MAJOR" -m "Update v$MAJOR tag"
-          git tag -fa "v$MAJOR.$MINOR" -m "Update v$MAJOR.$MINOR tag"
+          git tag -f "v$MAJOR" "v$RELEASE"
           git push origin "v$MAJOR" --force
-          git push origin "v$MAJOR.$MINOR" --force

--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -44,7 +44,7 @@ jobs:
           echo last_release_version - ${{ steps.rc.outputs.last_release_version }}
           echo new_release_major_version - ${{ steps.rc.outputs.new_release_major_version }}
       
-      - name: create major/minor release tag
+      - name: create major release tag
         if: steps.rc.outputs.new_release_published == 'true'
         env:
           MAJOR: ${{ steps.rc.outputs.new_release_major_version }}


### PR DESCRIPTION
## Description

Changing the way we tag major releases, to tag a release tag, not a release commit.

## Motivation and Context

Previous approach caused the upstream workflows to fail when calling reusable workflows in this repo by major version tag, like `.../pr_ci.yml@v1`. This usually happened to workflows run from default branch.

## How Has This Been Tested?

Tested on [Azure repo copy](https://github.com/PaloAltoNetworks/vm-series-gh-actions/actions/runs/5455784013)

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
