### PR TITLE
ci: fix schedule for pre-commit update job

### DIFF
--- a/.github/workflows/_pre-commit-update.yml
+++ b/.github/workflows/_pre-commit-update.yml
@@ -1,4 +1,4 @@
-name: Pre-Commit update
+name: (sub) Pre-Commit update
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: 0 1 1-7 * 1 # This is basically every 1st Monday of each month
+    - cron: 0 1 1 * *  # 1am of every 1st day of every month
 
 jobs:
   update:


### PR DESCRIPTION
## Description

Switch schedule to every 1st day of every month @1am.

## Motivation and Context

The original schedule didn't work as expected. Job was run on every Monday and every 1st to 7th day of a month.

## How Has This Been Tested?

Online cron editor.

## Screenshots (if appropriate)



## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
