### PR TITLE
fix: validate job in releases reusable workflow

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -98,11 +98,18 @@ jobs:
     name: validate terraform code
     needs: tf_prereqs
     if: ${{ needs.tf_prereqs.outputs.modules != '' }}
-    uses: ./.github/workflows/_tf_validate.yml
+    uses: ./.github/workflows/_tf_test.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
+      cloud: ${{ inputs.cloud }}
       tf_version: ${{ inputs.tf_version }}
       paths: ${{ needs.tf_prereqs.outputs.modules }}
+      terratest_action: Validate
+      fail_fast: ${{ inputs.fail_fast }}
       max_parallel: ${{ inputs.validate_max_parallel }}
+    secrets: inherit
 
 
   test:


### PR DESCRIPTION
## Description

Replace the non-existing validate subworkflow

## Motivation and Context

The release CI was not fixed to use the new Terratest based sub-workflow

## How Has This Been Tested?

n/a

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
