### PR TITLE
fix!: Hardcoded name of the cloud for ChatOps test command

### DIFF
--- a/.github/workflows/test_command.yml
+++ b/.github/workflows/test_command.yml
@@ -21,6 +21,10 @@ on:
         description: 'The comment-id of the slash command'
         type: string
         required: true
+      cloud:
+        description: "Decide against which public cloud the code will be run. Possible values: azure, aws, gcp"
+        type: string
+        required: true
       branch:
         description: Branch on which the tests should run
         type: string
@@ -62,7 +66,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      cloud: azure
+      cloud: ${{ inputs.cloud }}
       tf_version: ${{ inputs.tf_version }}
       paths: ${{ needs.init.outputs.paths }}
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Description

PR delivers fix to remove hardcoded name of the cloud for ChatOps test command.

## Motivation and Context

Issue was detected while working on ChatOps for AWS.

## How Has This Been Tested?

Code was tested on internal clone of the repository for VM-Series modules in AWS.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
