### PR TITLE
ci: push minor release tag

### DIFF
--- a/.github/workflows/actions_release_ci.yml
+++ b/.github/workflows/actions_release_ci.yml
@@ -50,3 +50,4 @@ jobs:
           git tag -f "v$MAJOR" "v$RELEASE"
           git tag -f "v$MAJOR.$MINOR" "v$RELEASE"
           git push origin "v$MAJOR" --force
+          git push origin "v$MAJOR.$MINOR" --force


### PR DESCRIPTION
## Description

fix for the #67 PR

## Motivation and Context

Previous PR was adding the minor release tag, but it was not pushing it to the repo.

## How Has This Been Tested?

Tested locally by updating the current release with a minor release tag.

## Screenshots (if appropriate)

![image](https://github.com/PaloAltoNetworks/terraform-modules-vmseries-ci-workflows/assets/42772730/448874a4-4254-4168-9899-fd4e2da7f7ff)


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
