### PR TITLE
fix!: Upgrade tflint from v0.47.0 to v0.48.0

### DIFF
--- a/.github/workflows/_pre_commit.yml
+++ b/.github/workflows/_pre_commit.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ matrix.pre_commit_hook == 'terraform_tflint' }}
         working-directory: /tmp
         run: |
-          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.47.0/tflint_linux_amd64.zip > tflint.zip
+          curl -sL https://github.com/terraform-linters/tflint/releases/download/v0.48.0/tflint_linux_amd64.zip > tflint.zip
           unzip tflint.zip
           mv tflint /usr/local/bin/
           tflint --version


### PR DESCRIPTION
## Description

PR upgrades version of `tflint`.

## Motivation and Context

While working on AWS modules, there were issues detected in newer version of `tflint` and described in https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/pull/396. 

## How Has This Been Tested?

`tflint` in version `0.48.0` was tested locally while working on https://github.com/PaloAltoNetworks/terraform-aws-vmseries-modules/pull/396.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
