### PR TITLE
feat: introduce apply_timeout to chatops command resuable workflow

### DIFF
--- a/.github/workflows/test_command.yml
+++ b/.github/workflows/test_command.yml
@@ -37,6 +37,10 @@ on:
         description: The action (name of a test in Terratest) that will be passed to the Makefile's ACTION parameter
         type: string
         required: true
+      apply_timeout:
+        description: Maximum time to run the Terraform apply step
+        type: number
+        default: 30
 
 jobs:
   init:
@@ -78,6 +82,7 @@ jobs:
       terratest_action: ${{ inputs.terratest_action }}
       fail_fast: false
       pr-id: ${{ inputs.pr-id }}
+      apply_timeout: ${{ inputs.apply_timeout }}
     secrets: inherit
   
   finish_comment_pr:


### PR DESCRIPTION
## Description

Add possibility to specify `apply_timeout` property to chatops command workflow.

## Motivation and Context

Since our code can sometimes be quite complex, default 30 minutes might not be enough to perform `apply` or `idempotence` tests. This gives an option to override this property from the calling workflow level. 

## How Has This Been Tested?

By running chatops idepomtence tests on Azure.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->


- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
